### PR TITLE
Add dsid summary to report, fix report links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Added`
 
 - DSId tab to final HTML report for DSId summary information if a DSId file was given as input [PR #10](https://github.com/phac-nml/measeq/pull/10)
+- New columns to final QC report based on wants [PR #10](https://github.com/phac-nml/measeq/pull/10)
+  - `genome_fasta` and `N450_fasta`
+  - Also adds a `overall.xlsx` file
 
 ### `Adjusted`
 
 - Fixed a bug with MeaSeq Report summary table not correctly linking to certain samples [PR #10](https://github.com/phac-nml/measeq/pull/10)
 - Removed `versions.yml` from being created during final report as versions already were reported [PR #10](https://github.com/phac-nml/measeq/pull/10)
 - Adjusted code for final report row formatting to match throughout Rmd files [PR #10](https://github.com/phac-nml/measeq/pull/10)
+- DSId assignment changes [PR #10](https://github.com/phac-nml/measeq/pull/10)
+  - Hash adjusted to 7 characters
+  - Semi-Complete removed to just be Incomplete
+- New container for the MAKE_FINAL_QC_CSV step [PR #10](https://github.com/phac-nml/measeq/pull/10)
+  - Add in openpyxl
 
 ## [v0.3.1] - 2025-07-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,14 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v0.3.2] - 2025-0X-XX
+## [v0.3.2] - 2025-08-01
 
 ### `Added`
 
 - DSId tab to final HTML report for DSId summary information if a DSId file was given as input [PR #10](https://github.com/phac-nml/measeq/pull/10)
-- New columns to final QC report based on wants [PR #10](https://github.com/phac-nml/measeq/pull/10)
-  - `genome_fasta` and `N450_fasta`
-  - Also adds a `overall.xlsx` file
+- New `overall.xlsx` final QC file based on adding in a few more columns [PR #10](https://github.com/phac-nml/measeq/pull/10)
+  - `genome_fasta` and `N450_fasta` that contain fasta formatted sequence data
+    - This broke the CSV file version parsing so that remains unchanged to get metadata to IRIDANext
 
 ### `Adjusted`
 
@@ -20,8 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - DSId assignment changes [PR #10](https://github.com/phac-nml/measeq/pull/10)
   - Hash adjusted to 7 characters
   - Semi-Complete removed to just be Incomplete
-- New container for the MAKE_FINAL_QC_CSV step [PR #10](https://github.com/phac-nml/measeq/pull/10)
-  - Add in openpyxl
+- New container for the MAKE_FINAL_QC_CSV step to remove artic container [PR #10](https://github.com/phac-nml/measeq/pull/10)
+  - Adds in openpyxl
 
 ## [v0.3.1] - 2025-07-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,28 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.3.2] - 2025-0X-XX
+
+### `Added`
+
+- DSId tab to final HTML report for DSId summary information if a DSId file was given as input [PR #10](https://github.com/phac-nml/measeq/pull/10)
+
+### `Adjusted`
+
+- Fixed a bug with MeaSeq Report summary table not correctly linking to certain samples [PR #10](https://github.com/phac-nml/measeq/pull/10)
+- Removed `versions.yml` from being created during final report as versions already were reported [PR #10](https://github.com/phac-nml/measeq/pull/10)
+- Adjusted code for final report row formatting to match throughout Rmd files [PR #10](https://github.com/phac-nml/measeq/pull/10)
+
 ## [v0.3.1] - 2025-07-29
 
 ### `Adjusted`
 
-- Fixed a bug where the irida json file wasn't being populated with metadata [PR #7](https://github.com/phac-nml/measeq/pull/7)
-- Adjusted Illumina nf-test to use the `sample_name` field of the samplesheet to test that it works [PR #7](https://github.com/phac-nml/measeq/pull/7)
+- Fixed a bug where the irida json file wasn't being populated with metadata [PR #8](https://github.com/phac-nml/measeq/pull/8)
+- Adjusted Illumina nf-test to use the `sample_name` field of the samplesheet to test that it works [PR #8](https://github.com/phac-nml/measeq/pull/8)
 
 ### `Removed`
 
-- Normalized median read depth plot for now as it overlaps the full depth one too much [PR #7](https://github.com/phac-nml/measeq/pull/7)
+- Normalized median read depth plot for now as it overlaps the full depth one too much [PR #8](https://github.com/phac-nml/measeq/pull/8)
 
 ## [v0.3.0] - 2025-07-25
 
@@ -88,6 +100,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - MeaSeq pipeline created and initial code added
 
+[v0.3.2]: https://github.com/phac-nml/measeq/releases/tag/0.3.2
 [v0.3.1]: https://github.com/phac-nml/measeq/releases/tag/0.3.1
 [v0.3.0]: https://github.com/phac-nml/measeq/releases/tag/0.3.0
 [v0.2.1-dev]: https://github.com/phac-nml/measeq/releases/tag/0.2.1-dev

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ _Note_: The first line in the example file is just to display what each line exp
 
 While 24 MeV genotypes were initially identified, only 2 have been detected since 2021: B3 and D8. Due to this, the Distinct Sequence Identifier (DSId) system was created to designate a unique 4-digit identifier based on the precise N450 sequence as a sub-genotype nomenclature. The [Measles Nucleotide Surveillance database](https://who-gmrln.org/means2) (MeaNS) is the global resource for these measles virus genetic sequences that is maintained by the WHO. N450 sequences can be submitted to the database to generate a distinct sequence identifier (DSId) for each unique sequence.
 
-There is no way to query the current database so a multifasta file with DSId calls is required to match them up locally. If a match is found, the matching DSId is assigned! If no match is found, the distinct sequence is given a `Novel-<MD5 HASH>` (first 5 characters for now) identifier so that it can be submitted to the database. To do this, use the parameter `--dsid_fasta <FASTA>`. The fasta file would look as such:
+There is no way to query the current database so a multifasta file with DSId calls is required to match them up locally. If a match is found, the matching DSId is assigned! If no match is found, the distinct sequence is given a `Novel-<MD5 HASH>` (first 7 characters for now) identifier so that it can be submitted to the database. To do this, use the parameter `--dsid_fasta <FASTA>`. The fasta file would look as such:
 
 **dsid_fasta**
 

--- a/assets/MeaSeq_Report.Rmd
+++ b/assets/MeaSeq_Report.Rmd
@@ -154,20 +154,20 @@ clean_name <- function(x) {
   # Track values
   out <- character(length(x))
   seen <- list()
-  section_count <- 8 # Start at 8 because thats how it goes apparently
+  section_count <- 7 # Start at 7 because thats how it goes apparently
   
   for (i in seq_along(x)) {
     name <- x[i]
     
     if (grepl("^\\d+$", name)) {
-      # All numeric get section-8, section-14
+      # All numeric get section-7, section-14
       base <- "section"
       name_clean <- paste0(base, "-", section_count)
       # Count updates by 6...
       section_count <- section_count + 6
     } else {
-      # Remove leading numbers
-      name_clean <- sub("^\\d+", "", name)
+      # Remove everything before the first alphabetical character
+      name_clean <- sub("^[^a-zA-Z]*([a-zA-Z].*)", "\\1", name)
       # Replace _ and space with -
       name_clean <- gsub("[ _]+", "-", name_clean)
       # Count still updates but by 5...
@@ -235,6 +235,9 @@ summary_df$status_colour_code <- add_pass_value_int(summary_df, 'qc_status')
 failed_samples <- summary_df %>%
   filter(genome_completeness_percent < 50 & qc_status != "PASS") %>%
   pull(sample)
+
+# Determine if we have DSIds to summarize
+run_dsid <- any(!is.na(summary_df$matched_dsid) & nzchar(summary_df$matched_dsid))
 
 # Gene Info based on final length
 #  Currently only full genomes (~15894bp) and genomes with the 5' and 3' UTR cut (~15678bp) as references so
@@ -523,6 +526,13 @@ for ( sample_v in samples ) {
 <!-- ---------------------- -->
 <!-- Back to normal Rmd doc -->
 <!-- ---------------------- -->
+
+<!-- ---------------------------------------------------------- -->
+<!-- DSId Page if used                                          -->
+<!-- ---------------------------------------------------------- -->
+
+```{r dsid_page, child="subpage_dsid.Rmd", params=params, eval=run_dsid}
+```
 
 Providence
 =================================

--- a/assets/subpage_dsid.Rmd
+++ b/assets/subpage_dsid.Rmd
@@ -30,7 +30,7 @@ dsid_dt <- dsid_grouped_df %>%
     ),
     options = list(
       pageLength = 20,
-      order = list(list(0, 'asc'), list(2, 'desc')),
+      order = list(list(0, 'asc'), list(2, 'desc'), list(1, 'desc')),
       scrollX = FALSE,
       scrollY = "",
       columnDefs = list(

--- a/assets/subpage_dsid.Rmd
+++ b/assets/subpage_dsid.Rmd
@@ -19,8 +19,7 @@ dsid_df <- select(summary_df,
 dsid_grouped_df <- dsid_df %>%
   filter(!is.na(Genotype) & !is.na(`Matched DSId`)) %>%
   group_by(Genotype, `Matched DSId`) %>%
-  summarise(Count = n(), .groups = "drop") %>%
-  arrange(desc(Count))
+  summarise(Count = n(), .groups = "drop")
 
 # Create normal DT like other parts have
 dsid_dt <- dsid_grouped_df %>%
@@ -30,8 +29,8 @@ dsid_dt <- dsid_grouped_df %>%
       htmltools::strong('Table III: '), 'DSId Summary Table'
     ),
     options = list(
-      dom = 't',
-      paging = FALSE,
+      pageLength = 20,
+      order = list(list(0, 'asc'), list(2, 'desc')),
       scrollX = FALSE,
       scrollY = "",
       columnDefs = list(

--- a/assets/subpage_dsid.Rmd
+++ b/assets/subpage_dsid.Rmd
@@ -1,0 +1,57 @@
+<!-- Dynamically create dsid tab if we have that information -->
+
+DSId Summary
+=================================
+
+## Row
+
+### {-}
+
+```{r dsid_table}
+# Select the 3 needed cols
+dsid_df <- select(summary_df,
+  Sample,
+  Genotype,
+  `Matched DSId`
+)
+
+# Group and sort
+dsid_grouped_df <- dsid_df %>%
+  filter(!is.na(Genotype) & !is.na(`Matched DSId`)) %>%
+  group_by(Genotype, `Matched DSId`) %>%
+  summarise(Count = n(), .groups = "drop") %>%
+  arrange(desc(Count))
+
+# Create normal DT like other parts have
+dsid_dt <- dsid_grouped_df %>%
+  datatable(rownames = FALSE,
+    caption = htmltools::tags$caption(
+      style = 'caption-side: top',
+      htmltools::strong('Table III: '), 'DSId Summary Table'
+    ),
+    options = list(
+      dom = 't',
+      paging = FALSE,
+      scrollX = FALSE,
+      scrollY = "",
+      columnDefs = list(
+        list(className = 'dt-left', targets = "_all")
+      )
+    )
+  ) %>%
+  formatStyle(
+    'Count',
+    background = styleColorBar(range(0, max(dsid_grouped_df$Count)), 'lightblue', angle = -90),
+    backgroundSize = '88% 88%',
+    backgroundRepeat = 'no-repeat',
+    backgroundPosition = 'left'
+  )
+
+dsid_dt
+```
+
+## Row {data-height=50}
+
+<footer>
+`r footer_str`
+</footer>

--- a/assets/subpage_sample.Rmd
+++ b/assets/subpage_sample.Rmd
@@ -1,8 +1,7 @@
 <!-- Dynamically create individual sample rmd pages under the same datanav menu -->
 `r paste0('# ', sample, '{data-navmenu="Sample Reports"}')`
 
-Row
-------------------------------
+## Row
 
 ### Sample Name
 ```{r, echo=FALSE, error=TRUE}
@@ -34,8 +33,7 @@ valueBox(
 )
 ```
 
-Row
-------------------------------
+## Row
 
 ### {-}
 ```{r, expanded_summary_table, echo=FALSE, error=TRUE}
@@ -88,8 +86,7 @@ sddt <- sample_df %>%
 sddt
 ```
 
-Row
-------------------------------
+## Row
 
 ### {-}
 ```{r, variant_plot, echo=FALSE, error=TRUE}
@@ -226,8 +223,7 @@ if (file.exists(var_f)) {
 ddt
 ```
 
-Row
-------------------------------
+## Row
 
 ### {-}
 ```{r, depth_plot, echo=FALSE, error=TRUE}
@@ -311,8 +307,7 @@ depthp
 ```
 > **Figure 3.** Positional genomic depth. The Y-axis is log-scaled so positions with no genomic depth have been set to 1 to allow a continuous visualization. Zones have been marked using a colour scheme where: 0-10 is red corresponding to masked sites, 10-30 is yellow corresponding to sites where there is a basecall but limited depth, and 30+ is green for positions with acceptable or better depth.
 
-Row
-------------------------------
+## Row
 
 ### {-}
 ```{r, qual_plot, echo=FALSE, error=TRUE}

--- a/bin/compare_dsid.py
+++ b/bin/compare_dsid.py
@@ -66,7 +66,7 @@ def load_dsids(dsid_fasta: Path) -> dict:
     return dsid_seqs
 
 
-def hash_seq(seq: str, length: int = 5) -> str:
+def hash_seq(seq: str, length: int = 7) -> str:
     '''
     Purpose:
     --------
@@ -118,16 +118,13 @@ def label_seqs(input_fasta: Path, dsid_seqs: dict, out: str) -> dict:
             sample = record.id.split('-N450')[0]
 
             # Check for N's and IUPACs before full matches
-            completeness = 100
+            completeness = 100.00
             if len(seq) == 0:
                 dsid = 'No Data'
             elif 'N' in seq:
                 n_pct = round((seq.count('N')/len(seq)) * 100, 2)
                 completeness = 100 - n_pct
-                if completeness > 90:
-                    dsid = 'Semi-Complete'
-                else:
-                    dsid = 'Incomplete'
+                dsid = 'Incomplete'
             elif any(nt in seq for nt in AMBIGUOUS_NT):
                 dsid = 'Ambiguous Base'
             elif seq in dsid_seqs:
@@ -159,9 +156,9 @@ def main():
     if novel_seqs and args.write_novel:
         with open('novel_dsids.tsv', 'w', newline='') as tsvfile:
             writer = csv.writer(tsvfile, delimiter='\t')
-            writer.writerow(['tmp_id', 'sequence'])
-            for seq, tmp_id in novel_seqs.items():
-                writer.writerow([tmp_id, seq])
+            writer.writerow(['novel_id', 'sequence'])
+            for seq, novel_id in novel_seqs.items():
+                writer.writerow([novel_id, seq])
 
 if __name__ == '__main__':
     main()

--- a/bin/summary_qc.py
+++ b/bin/summary_qc.py
@@ -147,6 +147,13 @@ def main() -> None:
     df['pipeline_name'] = 'measeq'
     df['pipeline_version'] = args.version
     df.sort_values(by='sample', inplace=True)
+
+    # Final CSV and Excel file
+    #  Two as the iridanext plugin cannot seem to parse the newline needed to
+    #  add in a fasta formatted sequence in a cell
+    #  Those cells then get cut from the overall.qc.csv file
+    df.to_excel('overall.xlsx', sheet_name='overall', index=False)
+    df.drop(columns=['N450_fasta', 'genome_fasta'], inplace=True)
     df.to_csv('overall.qc.csv', index=False)
 
 if __name__ == '__main__':

--- a/conf/iridanext.config
+++ b/conf/iridanext.config
@@ -9,7 +9,8 @@ iridanext {
             global = [
                 "**/MeaSeq_Report.html",
                 "**/Amplicon-Summary-MultiQC-Report_multiqc_report.html",
-                "**/pipeline_info/measeq_software_mqc_versions.yml"
+                "**/pipeline_info/measeq_software_mqc_versions.yml",
+                "**/novel_dsids.tsv"
             ]
             samples = [
                 "**/consensus/*.N450.fasta",

--- a/docs/output.md
+++ b/docs/output.md
@@ -418,6 +418,7 @@ Custom python script combined intermediate and final files to give concatenate a
 <summary>Output files</summary>
 
 - `overall.qc.csv`: Final combined QC information CSV file
+- `overall.xlsx`: Final combined QC information file in excel format that also has the genomes in fasta format
 
 </details>
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -390,7 +390,15 @@ Samtools depth is used to summarize the depth sequenced at all reference genome 
 
 #### Compare DSId
 
-Comparing the output N450 sequences to a multifasta DSId reference to determine if they match. The output is only saved under work as the DSId call is just added to the QC file right after.
+Comparing the output N450 sequences to a multifasta DSId reference to determine if they match. Novel DSIds are given a `Novel-<HASH>` ID so that they are easy to group and identify
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- `dsids.tsv`: TSV file containing each samples DSId call and the completeness of the region
+- `novel_dsids.tsv`: TSV file containing the different run `Novel-HASH` DSId calls along with its N450 sequence
+
+</details>
 
 #### Make Sample QC
 

--- a/modules/local/custom/custom_report/main.nf
+++ b/modules/local/custom/custom_report/main.nf
@@ -22,7 +22,6 @@ process MAKE_CUSTOM_REPORT {
 
     output:
     path "*.html", emit: html
-    path "versions.yml", emit: versions
     path version_yml, includeInputs: true, emit: full_versions // So iridanext plugin can find it
 
     when:
@@ -56,20 +55,10 @@ process MAKE_CUSTOM_REPORT {
             revision = '$revision',
             nf_version = '$nf_version'
         ))"
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        Measeq_Report: 0.1.0
-    END_VERSIONS
     """
 
     stub:
     """
     touch MeaSeq_Report.html
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        MeaSeq_Report: 0.1.0
-    END_VERSIONS
     """
 }

--- a/modules/local/qc/sample/main.nf
+++ b/modules/local/qc/sample/main.nf
@@ -11,8 +11,8 @@ process MAKE_SAMPLE_QC_CSV {
         'biocontainers/artic:1.7.4--pyhdfd78af_0' }"
 
     input:
-    tuple val(meta), path(bam), path(bai), path(consensus), path(depth_bed), path(nextclade_n450), path(nextclade_full),
-            path(vcf), path(tbi), path(read_json)
+    tuple val(meta), path(bam), path(bai), path(consensus), path(consensus_n450), path(depth_bed),
+            path(nextclade_n450), path(nextclade_full), path(vcf), path(tbi), path(read_json)
     path dsid
     val genotype
     path primer_bed
@@ -35,11 +35,13 @@ process MAKE_SAMPLE_QC_CSV {
     def seqPrimerArg = primer_bed ? "--seq_bed $primer_bed" : ""
 
     // Run
-    //  Note that the meta.irida_id is also here as we need to add a new column to pull it out
+    //  Note that the meta.irida_id is also here as we need to add is as a new column to pull it out
+    //  if it differs from the sample column
     """
     sample_qc.py \\
         --bam $bam \\
         --consensus $consensus \\
+        --consensus_n450 $consensus_n450 \\
         --depth $depth_bed \\
         --nextclade_n450 $nextclade_n450 \\
         --nextclade_custom $nextclade_full \\

--- a/modules/local/qc/summary/environment.yml
+++ b/modules/local/qc/summary/environment.yml
@@ -3,4 +3,6 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::artic=1.7.4
+  - conda-forge::openpyxl=3.1.2
+  - conda-forge::pandas=2.2.0
+  - conda-forge::python=3.12.2

--- a/modules/local/qc/summary/main.nf
+++ b/modules/local/qc/summary/main.nf
@@ -6,8 +6,8 @@ process MAKE_FINAL_QC_CSV {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/artic:1.7.4--pyhdfd78af_0' :
-        'biocontainers/artic:1.7.4--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/mulled-v2-9941f0d0ff90a15b0f7804a7487c30957fb6e6cf:aa1fff77714712ab105e19c770efcb635ed300ff-0' :
+        'biocontainers/mulled-v2-9941f0d0ff90a15b0f7804a7487c30957fb6e6cf:aa1fff77714712ab105e19c770efcb635ed300ff-0' }"
 
     input:
     path concat_csv
@@ -18,6 +18,7 @@ process MAKE_FINAL_QC_CSV {
 
     output:
     path "overall.qc.csv", emit: csv
+    path "overall.xlsx", emit: xlsx
     path "versions.yml", emit: versions
 
     script:
@@ -36,18 +37,19 @@ process MAKE_FINAL_QC_CSV {
     # Versions #
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        artic: \$(echo \$(artic --version 2>&1) | sed 's/artic //')
+        python: \$(python --version | sed 's/Python //g')
     END_VERSIONS
     """
 
     stub:
     """
     touch overall.qc.csv
+    touch overall.xlsx
 
     # Versions #
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        artic: \$(echo \$(artic --version 2>&1) | sed 's/artic //')
+        python: \$(python --version | sed 's/Python //g')
     END_VERSIONS
     """
 }

--- a/subworkflows/local/generate_report/main.nf
+++ b/subworkflows/local/generate_report/main.nf
@@ -102,7 +102,6 @@ workflow GENERATE_REPORT {
         revision,
         nextflow.version
     )
-    ch_versions = ch_versions.mix(MAKE_CUSTOM_REPORT.out.versions)
 
     emit:
     versions = ch_versions

--- a/tests/main.nf.test
+++ b/tests/main.nf.test
@@ -131,6 +131,7 @@ nextflow_pipeline {
             // Final Reports
             assert path("$launchDir/results/Amplicon-Summary-MultiQC-Report_multiqc_report.html").exists()
             assert path("$launchDir/results/MeaSeq_Report.html").exists()
+            assert path("$launchDir/results/overall.xlsx").exists()
 
             // IRIDA Next output
             def iridanext_json = path("$launchDir/results/iridanext.output.json").json
@@ -224,6 +225,7 @@ nextflow_pipeline {
 
             // Final Reports
             assert path("$launchDir/results/MeaSeq_Report.html").exists()
+            assert path("$launchDir/results/overall.xlsx").exists()
 
             // IRIDA Next output
             def iridanext_json = path("$launchDir/results/iridanext.output.json").json

--- a/workflows/measeq.nf
+++ b/workflows/measeq.nf
@@ -176,6 +176,7 @@ workflow MEASEQ {
     MAKE_SAMPLE_QC_CSV(
         ch_bam_bai
             .join(ch_consensus, by: [0])
+            .join(ADJUST_N450_FASTA_HEADER.out.consensus, by: [0])
             .join(SAMTOOLS_DEPTH.out.tsv, by: [0])
             .join(NEXTCLADE_RUN_N450.out.csv, by: [0])
             .join(NEXTCLADE_RUN_CUSTOM.out.csv, by: [0])


### PR DESCRIPTION
Added in a tab to the final report that includes a small dsid summary table if the pipeline was ran with dsid information

Fixed a small bug in pipeline linking from the summary table to the individual sample page

Also removed the versions file from the final report as it isn't going to be tracked anywhere with the current pipeline structure

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
