### PR TITLE
Adjust and add in more DSId info

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
 
       - name: Set up Nextflow
-        uses: nf-core/setup-nextflow@v2
+        uses: nf-core/setup-nextflow@v1
         with:
           version: "${{ matrix.NXF_VER }}"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
 
       - name: Set up Nextflow
-        uses: nf-core/setup-nextflow@v1
+        uses: nf-core/setup-nextflow@v2
         with:
           version: "${{ matrix.NXF_VER }}"
 
@@ -50,9 +50,11 @@ jobs:
           sudo mv nf-test /usr/local/bin/
 
       - name: Run nf-test
+        continue-on-error: ${{ matrix.NXF_VER == 'latest-everything' }}
         run: |
           nf-test test --verbose
 
       - name: "Run pipeline with test data ${{ matrix.NXF_VER }} | ${{ matrix.test_name }} | docker"
+        continue-on-error: ${{ matrix.NXF_VER == 'latest-everything' }}
         run: |
           nextflow run ${GITHUB_WORKSPACE} -profile ${{ matrix.test_name }},docker --outdir ./results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.4.0] - 2025-09-03
+
+### `Added`
+
+- 3 columns to final Excel and CSV file [PR #12](https://github.com/phac-nml/measeq/pull/12)
+  - N450_completeness
+  - N450_mean_depth
+  - N450_status
+- Fail tracking for all samples and runs where every sample fails [PR #12](https://github.com/phac-nml/measeq/pull/12)
+
+### `Adjusted`
+
+- Adjusted the DSId final report page to have a list of all individual sample calls and the summary data shown
+- Added the N450 status to the initial report summary page
+- Always run the DSId check even with no database fasta file
+  - Everything will be labeled as `novel-hash` but it will group them up
+- Updated CI tests
+
 ## [v0.3.2] - 2025-08-01
 
 ### `Added`
@@ -108,6 +126,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - MeaSeq pipeline created and initial code added
 
+[v0.4.0]: https://github.com/phac-nml/measeq/releases/tag/0.4.0
 [v0.3.2]: https://github.com/phac-nml/measeq/releases/tag/0.3.2
 [v0.3.1]: https://github.com/phac-nml/measeq/releases/tag/0.3.1
 [v0.3.0]: https://github.com/phac-nml/measeq/releases/tag/0.3.0

--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ GTCAGTTCCACATTGGCATCAGAACTCG
 GTCAGTTCCACAGTGGCATCTGAACTCG
 ```
 
+If this parameter is not given, the DSIds will still be generated as hashes to group up samples in the dsid.tsv and in the final report.
+
 ### More Run Options
 
 For more detailed running options including adding metadata, adjusting parameters, adding in DSID matches, and more, please refer to [the usage docs](docs/usage.md).

--- a/README.md
+++ b/README.md
@@ -25,12 +25,13 @@
 
 ## Current Updates
 
-### _2025-07-18_
+### _2025-09-03_
 
 - Illumina and Nanopore workflows fully functional with the same (or equivalent) outputs
 - Dependency management fully available with `Docker`, `Singularity`, and `Conda`
 - Can assign DSIds from reference multi-fasta file and give new N450s a `Novel-hash` label
   - With `--dsid_fasta <FASTA>`
+  - If no DISd fasta file available, it will assign all N450 as `Novel-hash` with hashes matching if the sequence is the same
 
 ## Introduction
 

--- a/assets/MeaSeq_Report.Rmd
+++ b/assets/MeaSeq_Report.Rmd
@@ -311,6 +311,9 @@ summary_df <- summary_df %>%
     "Frameshifts" = frameshifts,
     "Premature Stop Codon" = nonsense_mutation,
     "Mutated Stop Codon" = mutated_stop_codon,
+    "N450 Completeness" = N450_completeness,
+    "N450 Mean Depth" = N450_mean_depth,
+    "N450 Status" = N450_status,
     "QC Status" = qc_status,
     "Run Status" = run_status,
     "Run Summary" = run_summary
@@ -360,6 +363,7 @@ metrics_df <- select(summary_df,
   `Total Variants`,
   `Genome Completeness (%)`,
   `Genome Length`,
+  `N450 Status`,
   `QC Status`,
   status_colour_code
 )

--- a/assets/MeaSeq_Report.Rmd
+++ b/assets/MeaSeq_Report.Rmd
@@ -97,6 +97,9 @@ email <- params$email
 phone <- params$phone
 website <- params$website
 
+# Run contact sheet
+run_contact <- any(nzchar(name), nzchar(phone), nzchar(email), nzchar(website))
+
 # Create Header function
 catHeader <- function(text = "", level = 3) {
   cat(
@@ -622,83 +625,9 @@ version_dt <- df %>%
 version_dt
 ```
 
-Contact Information
-=================================
+<!-- ---------------------------------------------------------- -->
+<!-- Contact Page if used                                       -->
+<!-- ---------------------------------------------------------- -->
 
-<style>
-/* Flip Box Container */
-.flip-box {
-  background-color: transparent;
-  width: 700px;
-  height: 400px;
-  border: 1px solid #ccc;
-  perspective: 1000px;
-  margin: auto;
-}
-
-/* Flip Box Inner */
-.flip-box-inner {
-  position: relative;
-  width: 100%;
-  height: 100%;
-  text-align: center;
-  transition: transform 0.6s;
-  transform-style: preserve-3d;
-}
-
-/* Flip Box on Hover */
-.flip-box:hover .flip-box-inner {
-  transform: rotateY(180deg);
-}
-
-/* Front & Back Side */
-.flip-box-front, .flip-box-back {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  backface-visibility: hidden;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 10px;
-}
-
-/* Front Side */
-.flip-box-front {
-  background-color: #2C3E50;
-  color: white !important;
-}
-
-/* Back Side */
-.flip-box-back {
-  background-color: #95A5A6;
-  color: white !important;
-  transform: rotateY(180deg);
-}
-</style>
-
-
-```{r contact-info, warnings=FALSE, echo=FALSE}
-if (any(nzchar(name), nzchar(phone), nzchar(email), nzchar(website))){
-  back_content <- div(
-    if (name != "") h2(name),
-    if (email != "") p(strong("Email:"), email),
-    if (phone != "") p(strong("Phone Number:"), phone),
-    if (website != "") p("Website: ", a(href= paste0(website), website))
-  )
-} else {
-  back_content <- div(
-    h2("Contact Information Not Provided")
-  )
-}
-flip_box( 
-  front = div( 
-    h2("Contact Info"), p("Click to reveal details"), icon("address-card", class = "fa-6x") 
-  ), 
-  back = back_content
-)
+```{r contact_page, child="subpage_contact.Rmd", params=params, eval=run_contact}
 ```
-
-<footer>
-`r footer_str`
-</footer>

--- a/assets/MeaSeq_Report.Rmd
+++ b/assets/MeaSeq_Report.Rmd
@@ -245,16 +245,16 @@ run_dsid <- any(!is.na(summary_df$matched_dsid) & nzchar(summary_df$matched_dsid
 # Gene Info based on final length
 #  Currently only full genomes (~15894bp) and genomes with the 5' and 3' UTR cut (~15678bp) as references so
 #  use that to determine location of gene boxes for some plots instead of needing to load in a GFF (at the moment)
-gene_label <- c("N", "P/V/C", "M", "F", "H", "L")
-gene_color <- c("#0A9F9D", "#C52E19", "#6C8645", "#F98400", "#5BBCD6", "#F2AD00")
+gene_label <- c("N", "N450", "P/V/C", "M", "F", "H", "L")
+gene_color <- c("#0A9F9D", "#044342", "#C52E19", "#6C8645", "#F98400", "#5BBCD6", "#F2AD00")
 if ( max(summary_df$genome_length) < 15800 ) {
-  gene_start <- c(1, 1700, 3331, 5351, 7164, 9127)
-  gene_end <- c(1578, 3233, 4338, 7003, 9017, 15678)
-  gene_label_loc <- c(789, 2466, 3834, 6177, 8090, 12402)
+  gene_start <- c(1, 1128, 1700, 3331, 5351, 7164, 9127)
+  gene_end <- c(1578, 1578, 3233, 4338, 7003, 9017, 15678)
+  gene_label_loc <- c(789, 1353, 2466, 3834, 6177, 8090, 12402)
 } else {
-  gene_start <- c(108, 1807, 3438, 5458, 7271, 9234)
-  gene_end <- c(1685, 3330, 4445, 7110, 9124, 15785)
-  gene_label_loc <- c(896, 2568, 3941, 6284, 8197, 12509)
+  gene_start <- c(108, 1235, 1807, 3438, 5458, 7271, 9234)
+  gene_end <- c(1685, 1685, 3330, 4445, 7110, 9124, 15785)
+  gene_label_loc <- c(896, 1460, 2568, 3941, 6284, 8197, 12509)
 }
 # Gene Rectangles for Plotly
 gene_shapes_normal <- lapply(seq_along(gene_start), function(i) {
@@ -473,22 +473,25 @@ p <- ggplot(summary_depth_df, aes(x = position)) +
     panel.grid.major.x = element_line(color = "#dadce0", linetype = "dotted")
   )
 
-# Add Genes - Going to have to rethink this as its scale is a bit wonky with the data
-# p <- p +
-#   geom_rect(
-#     data = gene_df,
-#     aes(xmin = start, xmax = end, ymin = -4, ymax = -1.5),
-#     fill = gene_df$color,
-#     color = "black",
-#     inherit.aes = FALSE
-#   ) +
-#   geom_text(
-#     data = gene_df,
-#     aes(x = label_pos, y = -6.5, label = label),
-#     size = 3,
-#     inherit.aes = FALSE
-#   ) +
-#   expand_limits(y = -5)
+# Add Genes - Scale based on max
+box_size_adj <- round(max(2.5, 0.0425 * max(summary_depth_df$ymax)), 0)
+box_ymin <- -5 - box_size_adj
+text_y <- -5 - box_size_adj * 2.15
+
+p <- p +
+  geom_rect(
+    data = gene_df,
+    aes(xmin = start, xmax = end, ymin = box_ymin, ymax = -5),
+    fill = gene_df$color,
+    color = "black",
+    inherit.aes = FALSE
+  ) +
+  geom_text(
+    data = gene_df,
+    aes(x = label_pos, y = text_y, label = label),
+    size = 3,
+    inherit.aes = FALSE
+  )
 
 p
 ```

--- a/assets/ci-samplesheet.csv
+++ b/assets/ci-samplesheet.csv
@@ -1,3 +1,4 @@
 sample,fastq_1,fastq_2,sample_name
 add_sample1,https://github.com/phac-nml/measeq/raw/main/test_data/illumina_fastqs/SRR7517490_R1.fastq.gz,https://github.com/phac-nml/measeq/raw/main/test_data/illumina_fastqs/SRR7517490_R2.fastq.gz,sample1
 add_sample2,https://github.com/phac-nml/measeq/raw/main/test_data/illumina_fastqs/SRR7517498_R1.fastq.gz,https://github.com/phac-nml/measeq/raw/main/test_data/illumina_fastqs/SRR7517498_R2.fastq.gz,sample2
+add_empty,https://github.com/phac-nml/measeq/raw/dev/test_data/illumina_fastqs/empty_R1.fastq.gz,https://github.com/phac-nml/measeq/raw/dev/test_data/illumina_fastqs/empty_R2.fastq.gz,empty

--- a/assets/subpage_contact.Rmd
+++ b/assets/subpage_contact.Rmd
@@ -1,0 +1,82 @@
+<!-- Dynamically create dsid tab if we have that information -->
+
+Contact Information
+=================================
+
+<style>
+/* Flip Box Container */
+.flip-box {
+  background-color: transparent;
+  width: 700px;
+  height: 400px;
+  border: 1px solid #ccc;
+  perspective: 1000px;
+  margin: auto;
+}
+
+/* Flip Box Inner */
+.flip-box-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  text-align: center;
+  transition: transform 0.6s;
+  transform-style: preserve-3d;
+}
+
+/* Flip Box on Hover */
+.flip-box:hover .flip-box-inner {
+  transform: rotateY(180deg);
+}
+
+/* Front & Back Side */
+.flip-box-front, .flip-box-back {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  backface-visibility: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 10px;
+}
+
+/* Front Side */
+.flip-box-front {
+  background-color: #2C3E50;
+  color: white !important;
+}
+
+/* Back Side */
+.flip-box-back {
+  background-color: #95A5A6;
+  color: white !important;
+  transform: rotateY(180deg);
+}
+</style>
+
+
+```{r contact-info, warnings=FALSE, echo=FALSE}
+if (any(nzchar(name), nzchar(phone), nzchar(email), nzchar(website))){
+  back_content <- div(
+    if (name != "") h2(name),
+    if (email != "") p(strong("Email:"), email),
+    if (phone != "") p(strong("Phone Number:"), phone),
+    if (website != "") p("Website: ", a(href= paste0(website), website))
+  )
+} else {
+  back_content <- div(
+    h2("Contact Information Not Provided")
+  )
+}
+flip_box( 
+  front = div( 
+    h2("Contact Info"), p("Click to reveal details"), icon("address-card", class = "fa-6x") 
+  ), 
+  back = back_content
+)
+```
+
+<footer>
+`r footer_str`
+</footer>

--- a/assets/subpage_dsid.Rmd
+++ b/assets/subpage_dsid.Rmd
@@ -72,7 +72,15 @@ dsid_dt <- dsid_df %>%
         list(className = 'dt-left', targets = "_all")
       )
     )
-  )
+  ) %>%
+  # Bars to show at a glance
+    formatStyle(
+      'N450 Completeness',
+      background = styleColorBar(range(0,100), 'lightblue', angle = -90),
+      backgroundSize = '88% 88%',
+      backgroundRepeat = 'no-repeat',
+      backgroundPosition = 'left'
+    )
 
 dsid_dt
 ```

--- a/assets/subpage_dsid.Rmd
+++ b/assets/subpage_dsid.Rmd
@@ -7,12 +7,15 @@ DSId Summary
 
 ### {-}
 
-```{r dsid_table}
-# Select the 3 needed cols
+```{r dsid_summary_table}
+# Select the needed cols
 dsid_df <- select(summary_df,
   Sample,
   Genotype,
-  `Matched DSId`
+  `Matched DSId`,
+  `N450 Completeness`,
+  `N450 Mean Depth`,
+  `N450 Status`
 )
 
 # Group and sort
@@ -22,7 +25,7 @@ dsid_grouped_df <- dsid_df %>%
   summarise(Count = n(), .groups = "drop")
 
 # Create normal DT like other parts have
-dsid_dt <- dsid_grouped_df %>%
+dsid_sum_dt <- dsid_grouped_df %>%
   datatable(rownames = FALSE,
     caption = htmltools::tags$caption(
       style = 'caption-side: top',
@@ -44,6 +47,31 @@ dsid_dt <- dsid_grouped_df %>%
     backgroundSize = '88% 88%',
     backgroundRepeat = 'no-repeat',
     backgroundPosition = 'left'
+  )
+
+dsid_sum_dt
+```
+
+## Row
+
+### {-}
+
+```{r dsid_sample_table}
+# Create normal DT like other parts have
+dsid_dt <- dsid_df %>%
+  datatable(rownames = FALSE,
+    caption = htmltools::tags$caption(
+      style = 'caption-side: top',
+      htmltools::strong('Table IIII: '), 'DSId Sample Table'
+    ),
+    options = list(
+      pageLength = 20,
+      scrollX = FALSE,
+      scrollY = "",
+      columnDefs = list(
+        list(className = 'dt-left', targets = "_all")
+      )
+    )
   )
 
 dsid_dt

--- a/bin/compare_dsid.py
+++ b/bin/compare_dsid.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-'''Compare all sample N450 sequences to reference database'''
+'''Compare all sample N450 sequences to reference database and assign new ones a hash dsid'''
 import argparse
 import csv
 import hashlib
@@ -16,18 +16,18 @@ def init_parser() -> argparse.ArgumentParser:
     """
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        '-d',
-        '--dsid_fasta',
-        required=True,
-        type=Path,
-        help='Path to input DSID Fasta database'
-    )
-    parser.add_argument(
         '-f',
         '--fasta',
         required=True,
         type=Path,
         help='Path to input multifasta file to check dsids for'
+    )
+    parser.add_argument(
+        '-d',
+        '--dsid_fasta',
+        required=False,
+        type=Path,
+        help='Path to input DSID Fasta database'
     )
     parser.add_argument(
         '-o',
@@ -147,8 +147,10 @@ def main():
     parser = init_parser()
     args = parser.parse_args()
 
-    # Create DSID Dict
-    dsid_seqs = load_dsids(args.dsid_fasta)
+    # Create DSID Dict if we have data
+    dsid_seqs = {}
+    if args.dsid_fasta:
+        dsid_seqs = load_dsids(args.dsid_fasta)
 
     # Label and output
     novel_seqs = label_seqs(args.fasta, dsid_seqs, args.outfile)

--- a/bin/sample_qc.py
+++ b/bin/sample_qc.py
@@ -462,10 +462,12 @@ def parse_n450_nextclade(nextclade_csv: Path, sample: str) -> Tuple[str, range]:
     if d:
         genotype = d['clade']
         # insertions structured as 0:BASES,450:BASES as all alignments will be 450 bp with the dataset used
-        to_n450 = len(d['insertions'].split(',')[0].split(':')[1])
+        to_n450 = 0
+        if ',' in d['insertions']:
+            to_n450 = len(d['insertions'].split(',')[0].split(':')[1])
         return genotype, range(to_n450+1, to_n450+451)
     else:
-        return '', range(1,1)
+        return '', range(1,452)
 
 
 def get_custom_nextclade_vals(nextclade_csv: Path, sample: str) -> Tuple[str, str, str]:

--- a/bin/summary_qc.py
+++ b/bin/summary_qc.py
@@ -106,7 +106,7 @@ def main() -> None:
     ]
 
     # Do stuff
-    df = pd.read_csv(args.csv, dtype={"matched_dsid": "string"}) # To not expand the integer values here
+    df = pd.read_csv(args.csv, dtype={"matched_dsid": "string", "sample": "string"}) # To not expand the integer values here
     validate_df_columns(df, ['sample', 'num_aligned_reads', 'genome_completeness_percent', 'mean_sequencing_depth', 'median_sequencing_depth', 'divisible_by_6', 'qc_status'])
 
     # Add in metadata if there is any
@@ -120,6 +120,7 @@ def main() -> None:
     if args.skip_ctrl_grading:
         run_control_status = 'PASS'
         run_control_info = 'Skipped'
+
     elif not neg_df.empty:
         # Check neg columns
         run_control_status = 'PASS'

--- a/conf/iridanext.config
+++ b/conf/iridanext.config
@@ -10,6 +10,7 @@ iridanext {
                 "**/MeaSeq_Report.html",
                 "**/Amplicon-Summary-MultiQC-Report_multiqc_report.html",
                 "**/pipeline_info/measeq_software_mqc_versions.yml",
+                "**/overall.xlsx",
                 "**/novel_dsids.tsv"
             ]
             samples = [

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -113,27 +113,27 @@ An example file can be [found here](../assets/metadata.tsv)
 
 A table containing all of the parameter descriptions. You can also do `nextflow run phac-nml/measeq --help` to get them on the command line
 
-| Parameter                   | Description                                                                         | Required      | Type    | Default          | Notes                                            |
-| --------------------------- | ----------------------------------------------------------------------------------- | ------------- | ------- | ---------------- | ------------------------------------------------ |
-| --input                     | Path to comma-separated file containing sample and read information                 | True          | Path    | null             |                                                  |
-| --outdir                    | Name of output directory to store results                                           | True          | String  | null             |                                                  |
-| --reference                 | Path to reference fasta file to map to                                              | True          | Path    | null             |                                                  |
-| --platform                  | Sequencing platform used, either 'illumina or nanopore'                             | True          | Choice  | null             |                                                  |
-| --model                     | Name of clair3 model to use                                                         | Nanopore data | String  | null             | Can use `--local_model` instead                  |
-| --local_model               | Path to local clair3 model to use                                                   | Nanopore data | Path    | null             | Can use `--model` instead if wanted              |
-| --primer_bed                | Path to bed file containing genomic primer locations                                | False         | Path    | null             | Use for amplicon data                            |
-| --min_ambiguity_threshold   | Minimum threshold to call a position as an IUPAC                                    | False         | Float   | 0.30             | Illumina only                                    |
-| --max_ambiguity_threshold   | Maximum threshold to call a position as an IUPAC                                    | False         | Float   | 0.75             | Illumina only                                    |
-| --min_indel_threshold       | Minimum thresholds to keep an indel                                                 | False         | Float   | 0.60             | Illumina only                                    |
-| --normalise_ont             | Normalise each amplicon barcode to set depth                                        | False         | Int     | 2000             | Nanopore only                                    |
-| --min_variant_qual_c3       | Minimum variant quality to pass clair3 filters                                      | False         | Int     | 8                | Nanopore only                                    |
-| --metadata                  | Path to metadata TSV file containing at minimum 'sample' column                     | False         | Path    | null             | See [Metadata TSV](#metadata-tsv)                |
-| --dsid_fasta                | Path to DSID multi-fasta to match output consensus data to                          | False         | Path    | null             | See [DSId Matching](#dsid-matching)              |
-| --min_depth                 | Minimum depth to call a base                                                        | False         | Int     | 10               |                                                  |
-| --no_frameshifts            | Fail all indel variants not divisible by 3                                          | False         | Boolean | False            | Somewhat crude filter, only use if really needed |
-| --neg_control_pct_threshold | Threshold of genome to be called in a negative control to fail it                   | False         | Int     | 10               |                                                  |
-| --neg_ctrl_substrings       | Substrings to match to sample names to identify negative controls. Separated by a , | False         | String  | neg,ntc,blank,en |                                                  |
-| --skip_negative_grading     | Skip grading negative controls and just output a PASS for Run QC                    | False         | Boolean | False            |                                                  |
+| Parameter                   | Description                                                                         | Required      | Type    | Default          | Notes                                             |
+| --------------------------- | ----------------------------------------------------------------------------------- | ------------- | ------- | ---------------- | ------------------------------------------------- |
+| --input                     | Path to comma-separated file containing sample and read information                 | True          | Path    | null             |                                                   |
+| --outdir                    | Name of output directory to store results                                           | True          | String  | null             |                                                   |
+| --reference                 | Path to reference fasta file to map to                                              | True          | Path    | null             |                                                   |
+| --platform                  | Sequencing platform used, either 'illumina or nanopore'                             | True          | Choice  | null             |                                                   |
+| --model                     | Name of clair3 model to use                                                         | Nanopore data | String  | null             | Can use `--local_model` instead                   |
+| --local_model               | Path to local clair3 model to use                                                   | Nanopore data | Path    | null             | Can use `--model` instead if wanted               |
+| --primer_bed                | Path to bed file containing genomic primer locations                                | False         | Path    | null             | Use for amplicon data                             |
+| --min_ambiguity_threshold   | Minimum threshold to call a position as an IUPAC                                    | False         | Float   | 0.30             | Illumina only                                     |
+| --max_ambiguity_threshold   | Maximum threshold to call a position as an IUPAC                                    | False         | Float   | 0.75             | Illumina only                                     |
+| --min_indel_threshold       | Minimum thresholds to keep an indel                                                 | False         | Float   | 0.60             | Illumina only                                     |
+| --normalise_ont             | Normalise each amplicon barcode to set depth                                        | False         | Int     | 2000             | Nanopore only                                     |
+| --min_variant_qual_c3       | Minimum variant quality to pass clair3 filters                                      | False         | Int     | 8                | Nanopore only                                     |
+| --metadata                  | Path to metadata TSV file containing at minimum 'sample' column                     | False         | Path    | null             | See [Metadata TSV](#metadata-tsv)                 |
+| --dsid_fasta                | Path to DSID multi-fasta to match output consensus data to                          | False         | Path    | null             | See [DSId Matching in README](../README.md#dsids) |
+| --min_depth                 | Minimum depth to call a base                                                        | False         | Int     | 10               |                                                   |
+| --no_frameshifts            | Fail all indel variants not divisible by 3                                          | False         | Boolean | False            | Somewhat crude filter, only use if really needed  |
+| --neg_control_pct_threshold | Threshold of genome to be called in a negative control to fail it                   | False         | Int     | 10               |                                                   |
+| --neg_ctrl_substrings       | Substrings to match to sample names to identify negative controls. Separated by a , | False         | String  | neg,ntc,blank,en |                                                   |
+| --skip_negative_grading     | Skip grading negative controls and just output a PASS for Run QC                    | False         | Boolean | False            |                                                   |
 
 ### Other Settings and Parameter Files
 

--- a/modules/local/custom/compare_internal_dsid/main.nf
+++ b/modules/local/custom/compare_internal_dsid/main.nf
@@ -25,10 +25,12 @@ process COMPARE_INTERNAL_DSID {
     path "versions.yml", emit: versions
 
     script:
+    // Add known dsid designations if we have them
+    def dsidArg = id_fasta ? "--dsid_fasta $id_fasta" : ""
     """
     compare_dsid.py \\
         --fasta $n450_fasta \\
-        --dsid_fasta $id_fasta \\
+        $dsidArg \\
         --write_novel
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/local/custom/normalize_depth_matrix/main.nf
+++ b/modules/local/custom/normalize_depth_matrix/main.nf
@@ -17,6 +17,7 @@ process NORMALIZE_DEPTH_MATRIX {
     '''
     Simple script to normalize and merge together all positional depth
     '''
+    import sys
     import pandas as pd
     from pathlib import Path
 
@@ -53,6 +54,15 @@ process NORMALIZE_DEPTH_MATRIX {
         else:
             outl.append(df[[name]])
 
+    # If everything is empty, just create 2 files with only col headers
+    if outl == []:
+        out_df_t = pd.DataFrame(columns=['', '1', '2', '3'])
+        concat_df = pd.DataFrame(columns=['position', 'mean', 'q1', 'q3', 'IQR'])
+        out_df_t.to_csv('sample_positional_normalized_depth.csv')
+        concat_df.to_csv('sample_positional_normalized_depth_stats.csv')
+        sys.exit(0)
+
+    # Summarize
     concat_df = pd.concat(outl, axis=1)
     concat_df = concat_df.set_index('position')
     out_df = concat_df.copy()

--- a/modules/local/qc/sample/main.nf
+++ b/modules/local/qc/sample/main.nf
@@ -29,8 +29,7 @@ process MAKE_SAMPLE_QC_CSV {
     } else {
         readJsonArg = "--nanoq_json $read_json"
     }
-    // Add matched dsid if we have it
-    def dsidArg = dsid ? "--matched_dsid $dsid" : ""
+
     // Add primer bed if we have it
     def seqPrimerArg = primer_bed ? "--seq_bed $primer_bed" : ""
 
@@ -47,8 +46,8 @@ process MAKE_SAMPLE_QC_CSV {
         --nextclade_custom $nextclade_full \\
         --genotype $genotype \\
         --vcf $vcf \\
+        --matched_dsid $dsid \\
         $readJsonArg \\
-        $dsidArg \\
         $seqPrimerArg \\
         --sample $meta.id \\
         --irida_id $meta.irida_id

--- a/nextflow.config
+++ b/nextflow.config
@@ -268,7 +268,7 @@ manifest {
     mainScript      = 'main.nf'
     defaultBranch   = 'main'
     nextflowVersion = '!>=24.10.0'
-    version         = '0.3.3'
+    version         = '0.4.0'
     doi             = ''
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -268,7 +268,7 @@ manifest {
     mainScript      = 'main.nf'
     defaultBranch   = 'main'
     nextflowVersion = '!>=24.10.0'
-    version         = '0.3.0'
+    version         = '0.3.3'
     doi             = ''
 }
 

--- a/tests/main.nf.test
+++ b/tests/main.nf.test
@@ -96,6 +96,7 @@ nextflow_pipeline {
             // Using the first 10 columns only to get to variants count
             lines = path("$launchDir/results/overall.qc.csv").text
             assert lines.contains("sample,genotype,matched_dsid,num_input_reads,num_aligned_reads,num_consensus_n,genome_completeness_percent,mean_sequencing_depth,median_sequencing_depth,total_variants,")
+            assert lines.contains("empty,NA,No Data,2,2,15894,0.0,0.02,0.0,0,")
             assert lines.contains("sample1,D8,Novel-bcb39a9,40476,39026,224,98.59,349.06,313.0,269,")
             assert lines.contains("sample2,D8,Novel-bcb39a9,56368,54181,233,98.53,484.7,483.0,273,")
 
@@ -114,6 +115,8 @@ nextflow_pipeline {
             // Sample Outputs
             //  Fasta regions match
             assert path("$launchDir/results/consensus/MH356245.1.N450.fasta").md5 == "79e89ca9bfb7213c3767b2011f9ffee8"
+            assert path("$launchDir/results/consensus/empty.consensus.fasta").md5 == "c14c11443f08b9976164ed80339150ca"
+            assert path("$launchDir/results/consensus/empty.N450.fasta").md5 == "d41d8cd98f00b204e9800998ecf8427e"
             assert path("$launchDir/results/consensus/sample1.consensus.fasta").md5 == "d7450179ac96cfda3e004a7bb74ea2fd"
             assert path("$launchDir/results/consensus/sample1.N450.fasta").md5 == "49dad01767d044fc73d87a6818765410"
             assert path("$launchDir/results/consensus/sample2.consensus.fasta").md5 == "fcba2244d3181d683411d99a8ace7ba2"
@@ -122,7 +125,7 @@ nextflow_pipeline {
             //  Reporting files
             assert path("$launchDir/results/reporting/sample_positional_normalized_depth.csv").exists()
             lines = path("$launchDir/results/reporting/sample_positional_normalized_depth.csv").readLines()
-            assert lines.size() == 3
+            assert lines.size() == 4
 
             assert path("$launchDir/results/reporting/sample_positional_normalized_depth_stats.csv").exists()
             lines = path("$launchDir/results/reporting/sample_positional_normalized_depth_stats.csv").readLines()

--- a/tests/main.nf.test
+++ b/tests/main.nf.test
@@ -96,7 +96,7 @@ nextflow_pipeline {
             // Using the first 10 columns only to get to variants count
             lines = path("$launchDir/results/overall.qc.csv").text
             assert lines.contains("sample,genotype,matched_dsid,num_input_reads,num_aligned_reads,num_consensus_n,genome_completeness_percent,mean_sequencing_depth,median_sequencing_depth,total_variants,")
-            assert lines.contains("empty,NA,No Data,2,2,15894,0.0,0.02,0.0,0,")
+            assert lines.contains("empty,NA,No Data,2,1,15894,0.0,0.0,0.0,0,")
             assert lines.contains("sample1,D8,Novel-bcb39a9,40476,39026,224,98.59,349.06,313.0,269,")
             assert lines.contains("sample2,D8,Novel-bcb39a9,56368,54181,233,98.53,484.7,483.0,273,")
 

--- a/tests/main.nf.test
+++ b/tests/main.nf.test
@@ -4,7 +4,7 @@ nextflow_pipeline {
     name "Full Pipeline NF-Tests for MeaSeq"
     script "main.nf"
 
-    //--- Test 1
+    //--- Test 1 ----------------------------------------------------------------------------
     test("No platform specified") {
         tag "fail"
 
@@ -24,7 +24,7 @@ nextflow_pipeline {
         }
     }
 
-    //--- Test 2
+    //--- Test 2 ----------------------------------------------------------------------------
     test("No Input Specified") {
         tag "fail"
 
@@ -44,7 +44,7 @@ nextflow_pipeline {
         }
     }
 
-    //--- Test 3
+    //--- Test 3 ----------------------------------------------------------------------------
     test("Missing Samplesheet Data") {
         tag "fail"
 
@@ -65,7 +65,7 @@ nextflow_pipeline {
         }
     }
 
-    //--- Test 4
+    //--- Test 4 ----------------------------------------------------------------------------
     test("Illumina Amplicon Data with Sample Name Completion") {
         tag "success"
 
@@ -96,8 +96,8 @@ nextflow_pipeline {
             // Using the first 10 columns only to get to variants count
             lines = path("$launchDir/results/overall.qc.csv").text
             assert lines.contains("sample,genotype,matched_dsid,num_input_reads,num_aligned_reads,num_consensus_n,genome_completeness_percent,mean_sequencing_depth,median_sequencing_depth,total_variants,")
-            assert lines.contains("sample1,D8,NA,40476,39026,224,98.59,349.06,313.0,269,")
-            assert lines.contains("sample2,D8,NA,56368,54181,233,98.53,484.7,483.0,273,")
+            assert lines.contains("sample1,D8,Novel-bcb39a9,40476,39026,224,98.59,349.06,313.0,269,")
+            assert lines.contains("sample2,D8,Novel-bcb39a9,56368,54181,233,98.53,484.7,483.0,273,")
 
             // Intermediate generated reference files
             assert path("$launchDir/results/reference/amplicon.bed").exists()
@@ -142,13 +142,15 @@ nextflow_pipeline {
             assert iridanext_global.findAll { it.path == "MeaSeq_Report.html" }.size() == 1
             assert iridanext_global.findAll { it.path == "pipeline_info/measeq_software_mqc_versions.yml" }.size() == 1
             assert iridanext_global.findAll { it.path == "Amplicon-Summary-MultiQC-Report_multiqc_report.html" }.size() == 1
+            assert iridanext_global.findAll { it.path == "overall.xlsx" }.size() == 1
+            assert iridanext_global.findAll { it.path == "novel_dsids.tsv" }.size() == 1
 
             assert iridanext_samples.add_sample1.findAll { it.path == "consensus/sample1.N450.fasta" }.size() == 1
             assert iridanext_samples.add_sample1.findAll { it.path == "consensus/sample1.consensus.fasta" }.size() == 1
             assert iridanext_samples.add_sample1.findAll { it.path == "vcf/processed_vcf/sample1.processed.norm.vcf.gz" }.size() == 1
 
             assert iridanext_metadata.add_sample1.genotype == "D8"
-            assert iridanext_metadata.add_sample1.matched_dsid == "NA"
+            assert iridanext_metadata.add_sample1.matched_dsid == "Novel-bcb39a9"
             assert iridanext_metadata.add_sample1.num_input_reads == "40476"
             assert iridanext_metadata.add_sample1.num_aligned_reads == "39026"
             assert iridanext_metadata.add_sample1.num_consensus_n == "224"
@@ -160,6 +162,9 @@ nextflow_pipeline {
             assert iridanext_metadata.add_sample1.num_iupac == "0"
             assert iridanext_metadata.add_sample1.genome_length == "15894"
             assert iridanext_metadata.add_sample1.divisible_by_6 == "True"
+            assert iridanext_metadata.add_sample1.N450_completeness == "100.0"
+            assert iridanext_metadata.add_sample1.N450_mean_depth == "313.58"
+            assert iridanext_metadata.add_sample1.N450_status == "PASS"
             assert iridanext_metadata.add_sample1.qc_status == "PASS"
 
             // Pipeline info and tracking
@@ -169,7 +174,7 @@ nextflow_pipeline {
         }
     }
 
-    //--- Test 4
+    //--- Test 5 ----------------------------------------------------------------------------
     test("Nanopore NON-Amplicon Data Completion") {
         tag "success"
 
@@ -200,7 +205,7 @@ nextflow_pipeline {
             // Using the first 10 columns only to get to variants count
             lines = path("$launchDir/results/overall.qc.csv").text
             assert lines.contains("sample,genotype,matched_dsid,num_input_reads,num_aligned_reads,num_consensus_n,genome_completeness_percent,mean_sequencing_depth,median_sequencing_depth,total_variants,")
-            assert lines.contains("sample1,D8,NA,9357,9353,3,99.98,385.07,239.0,274,")
+            assert lines.contains("sample1,D8,Novel-65d31ec,9357,9353,3,99.98,385.07,239.0,274,")
 
             // Intermediate generated reference files
             assert path("$launchDir/results/reference/genome.bed").exists()
@@ -235,13 +240,15 @@ nextflow_pipeline {
 
             assert iridanext_global.findAll { it.path == "MeaSeq_Report.html" }.size() == 1
             assert iridanext_global.findAll { it.path == "pipeline_info/measeq_software_mqc_versions.yml" }.size() == 1
+            assert iridanext_global.findAll { it.path == "overall.xlsx" }.size() == 1
+            assert iridanext_global.findAll { it.path == "novel_dsids.tsv" }.size() == 1
 
             assert iridanext_samples.sample1.findAll { it.path == "consensus/sample1.N450.fasta" }.size() == 1
             assert iridanext_samples.sample1.findAll { it.path == "consensus/sample1.consensus.fasta" }.size() == 1
             assert iridanext_samples.sample1.findAll { it.path == "vcf/final/sample1.pass.norm.vcf.gz" }.size() == 1
 
             assert iridanext_metadata.sample1.genotype == "D8"
-            assert iridanext_metadata.sample1.matched_dsid == "NA"
+            assert iridanext_metadata.sample1.matched_dsid == "Novel-65d31ec"
             assert iridanext_metadata.sample1.num_input_reads == "9357"
             assert iridanext_metadata.sample1.num_aligned_reads == "9353"
             assert iridanext_metadata.sample1.num_consensus_n == "3"
@@ -253,6 +260,9 @@ nextflow_pipeline {
             assert iridanext_metadata.sample1.num_iupac == "0"
             assert iridanext_metadata.sample1.genome_length == "15894"
             assert iridanext_metadata.sample1.divisible_by_6 == "True"
+            assert iridanext_metadata.sample1.N450_completeness == "100.0"
+            assert iridanext_metadata.sample1.N450_mean_depth == "217.72"
+            assert iridanext_metadata.sample1.N450_status == "PASS"
             assert iridanext_metadata.sample1.qc_status == "PASS"
 
             // Pipeline info and tracking

--- a/workflows/measeq.nf
+++ b/workflows/measeq.nf
@@ -158,17 +158,14 @@ workflow MEASEQ {
     //
     // MODULE: Compare to optional internal DSID fasta file to get DSID number
     //
-    ch_dsid_results = Channel.empty()
-    if( params.dsid_fasta ) {
-        COMPARE_INTERNAL_DSID(
-            ADJUST_N450_FASTA_HEADER.out.consensus
-                .map{ it -> it[1] }
-                .collectFile(name: 'N450.fasta', sort: { it.baseName }),
-            ch_id_fasta
-        )
-        ch_dsid_results = COMPARE_INTERNAL_DSID.out.dsid_tsv
-        ch_versions = ch_versions.mix(COMPARE_INTERNAL_DSID.out.versions.first())
-    }
+    COMPARE_INTERNAL_DSID(
+        ADJUST_N450_FASTA_HEADER.out.consensus
+            .map{ it -> it[1] }
+            .collectFile(name: 'N450.fasta', sort: { it.baseName }),
+        ch_id_fasta
+    )
+    ch_dsid_results = COMPARE_INTERNAL_DSID.out.dsid_tsv
+    ch_versions = ch_versions.mix(COMPARE_INTERNAL_DSID.out.versions.first())
 
     //
     // MODULE: Summarize all of the sample data into 1 CSV file per sample
@@ -182,7 +179,7 @@ workflow MEASEQ {
             .join(NEXTCLADE_RUN_CUSTOM.out.csv, by: [0])
             .join(ch_vcf, by: [0])
             .join(ch_read_json, by: [0]),
-        ch_dsid_results.collect().ifEmpty([]),
+        ch_dsid_results.collect(),
         ch_genotype,
         ch_primer_bed.collect().ifEmpty([])
     )


### PR DESCRIPTION
Adding in additional DSId/N450 columns and information based on feed back from the MMR team

`Additions`:
- 3 columns in the xlsx and csv file
    - N450_completeness
    - N450_mean_depth
    - N450_status
- Fail tracking for all samples

`Changes`
- Adjusted the DSId final report page to have a list of all individual sample calls and the summary data
- Added the N450 status to the initial summary page
- Always run the DSId check even with no given database to base it off of
    - It'll label everything as novel this way but it'll group them up
    - A later change may be to remove the `novel` part of the label and just have it be the hash
- Updated CI tests
- Bumped version to 0.4.0 for minor release

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
